### PR TITLE
fixing the midPoint Component to work with crv length instead of parameter

### DIFF
--- a/WombatGH/Midpoint.cs
+++ b/WombatGH/Midpoint.cs
@@ -13,7 +13,7 @@ namespace WombatGH
     public class Midpoint : GH_Component
     {
 
-        public Midpoint() : base("Midpoint", "MP", "Evaluates the midpoint of a curve.", "Wombat", "Curve")
+        public Midpoint() : base("Midpoint", "MP", "Evaluates the midpoint of a curve's length.", "Wombat", "Curve")
         {
         }
 
@@ -35,8 +35,8 @@ namespace WombatGH
             Curve crv = default(Curve);
             if (!DA.GetData("Curve", ref crv)) return;
 
-            crv.Domain = new Interval(0, 1);
-            Point3d mp = crv.PointAt(0.5);
+            double midLength = (crv.GetLength() / 2);
+            Point3d mp = crv.PointAtLength(midLength);
 
             DA.SetData("Midpoint", mp);
         }


### PR DESCRIPTION
Suggested fix to the midPoint component, it is currently misleading as the reparametrized curve parameter at 0.5 is not necessarily the curve's mid-point! See below snapshot to see the problem with more clarity:

![womBAT_midPoint_Fix](https://user-images.githubusercontent.com/38655738/60078756-eaebd980-976f-11e9-8369-42159e310665.png)

The suggested fix is to depend on the Curve length's mid-point instead.