### PR TITLE
make Version defined in WombatGHInfo consistent with AssemblyVersion

### DIFF
--- a/WombatGH/WombatGHInfo.cs
+++ b/WombatGH/WombatGHInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Reflection;
 using Grasshopper.Kernel;
 
 namespace WombatGH
@@ -17,8 +18,24 @@ namespace WombatGH
 
         public override string AuthorContact => "Brian.Ringley@woodsbagot.com; Andrew.Heumann@woodsbagot.com";
 
-        public override string Version => "1.1.0.0";
-        public override string AssemblyVersion => "1.1.0.0";
+        public override string Version
+        {
+            get
+            {
+                return AssemblyVersion;
+            }
+        }
+
+        public override string AssemblyVersion
+        {
+            get
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var assemblyName = new AssemblyName(assembly.FullName);
+                return assemblyName.Version.ToString();
+            }
+        }
+
         public override Bitmap AssemblyIcon => Properties.Resources.WombatGH_WOMBAT_TAB_ICON;
     }
 }


### PR DESCRIPTION
@Dre-Tas related to this issue: https://github.com/woodsbagot/WombatGH/issues/24
I found an even better solution, making use of [System.Reflection.AssemblyName](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.version?view=netframework-4.5)